### PR TITLE
Enable build on osx-arm64

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -20,6 +20,18 @@ jobs:
       osx_64_libarrow15:
         CONFIG: osx_64_libarrow15
         UPLOAD_PACKAGES: 'True'
+      osx_arm64_libarrow12:
+        CONFIG: osx_arm64_libarrow12
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_libarrow13:
+        CONFIG: osx_arm64_libarrow13
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_libarrow14:
+        CONFIG: osx_arm64_libarrow14
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_libarrow15:
+        CONFIG: osx_arm64_libarrow15
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/osx_arm64_libarrow12.yaml
+++ b/.ci_support/osx_arm64_libarrow12.yaml
@@ -1,0 +1,25 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '16'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+libarrow:
+- '12'
+macos_machine:
+- arm64-apple-darwin20.0.0
+rust_compiler:
+- rust
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_libarrow13.yaml
+++ b/.ci_support/osx_arm64_libarrow13.yaml
@@ -1,0 +1,25 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '16'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+libarrow:
+- '13'
+macos_machine:
+- arm64-apple-darwin20.0.0
+rust_compiler:
+- rust
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_libarrow14.yaml
+++ b/.ci_support/osx_arm64_libarrow14.yaml
@@ -1,0 +1,25 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '16'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+libarrow:
+- '14'
+macos_machine:
+- arm64-apple-darwin20.0.0
+rust_compiler:
+- rust
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_libarrow15.yaml
+++ b/.ci_support/osx_arm64_libarrow15.yaml
@@ -1,0 +1,25 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '16'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+libarrow:
+- '15'
+macos_machine:
+- arm64-apple-darwin20.0.0
+rust_compiler:
+- rust
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -46,6 +46,9 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+fi
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -77,6 +77,10 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     /bin/bash
 else
 
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    fi
+
     conda-build ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \

--- a/README.md
+++ b/README.md
@@ -89,6 +89,34 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/librerun-sdk-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_libarrow15" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>osx_arm64_libarrow12</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21888&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/librerun-sdk-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_libarrow12" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_libarrow13</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21888&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/librerun-sdk-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_libarrow13" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_libarrow14</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21888&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/librerun-sdk-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_libarrow14" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_libarrow15</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21888&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/librerun-sdk-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_libarrow15" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,9 @@
+build_platform:
+  osx_arm64: osx_64
 github:
   branch_name: main
   tooling_branch_name: main
 conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
+test: native_and_emulated


### PR DESCRIPTION
For consistency with the `rerun-sdk` feedstock. 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
